### PR TITLE
feat: add "alg" property to keys in certs 

### DIFF
--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -223,6 +223,7 @@ func (o *OIDCProvider) certsEndpoint(rw http.ResponseWriter, req *http.Request) 
 	jwks := &jose.JSONWebKeySet{
 		Keys: []jose.JSONWebKey{
 			{
+				Algorithm: "RS256",
 				KeyID: cryptutils.KeyID(o.privateKey.PublicKey),
 				Use:   "sig",
 				Key:   &o.privateKey.PublicKey,


### PR DESCRIPTION
This increases compatability with software using the "alg" field to check the key type. The field is optional in the spec so it is not wrong to omit it, but including it should not hurt.