### PR TITLE
Add external_id to token response

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -127,19 +127,19 @@ func (o *OIDCProvider) newSession(aroot string, values url.Values) *openid.Defau
 	return &openid.DefaultSession{
 		Claims: &jwt.IDTokenClaims{
 			Issuer:      aroot,
-			Subject:     values.Get("username"),
+			Subject:     values.Get("external_id"),
 			Audience:    []string{},
 			ExpiresAt:   time.Now().Add(time.Hour * 6),
 			IssuedAt:    time.Now(),
 			RequestedAt: time.Now(),
 			AuthTime:    time.Now(),
 			Extra: map[string]interface{}{
-				"email":          values.Get("email"),
-				"email_verified": true,
-				"picture":        values.Get("avatar_url"),
-				"name":           values.Get("name"),
-				"groups":         strings.Split(values.Get("groups"), ","),
-				"external_id":    values.Get("external_id"),
+				"email":              values.Get("email"),
+				"email_verified":     true,
+				"picture":            values.Get("avatar_url"),
+				"name":               values.Get("name"),
+				"groups":             strings.Split(values.Get("groups"), ","),
+				"preferred_username": values.Get("username"),
 			},
 		},
 		Headers: &jwt.Headers{

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -139,6 +139,7 @@ func (o *OIDCProvider) newSession(aroot string, values url.Values) *openid.Defau
 				"picture":        values.Get("avatar_url"),
 				"name":           values.Get("name"),
 				"groups":         strings.Split(values.Get("groups"), ","),
+				"external_id":    values.Get("external_id"),
 			},
 		},
 		Headers: &jwt.Headers{


### PR DESCRIPTION
The default response does not provide a unique ID to match on. Discourse emails / usernames are subject to change, so matching on those values can result in duplicate accounts created in external systems.

This one line change provides the discourse User ID in the token response. This flow allows our system to catch the user ID, and do an upsert to the user in our database regardless of what username, email, or other value they have set.