### PR TITLE
feat: add docker-compose.yml and corresponding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ podman run -d \
   ghcr.io/parkour-vienna/distrust:$VERSION
 ```
 
+Or tools like podman-compose or docker compose:
+
+```sh
+podman-compose up -d distrust
+```
+
 ## Configuration
 
 ### Configuring Discourse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  distrust:
+    image: ghcr.io/parkour-vienna/distrust:$VERSION
+    container_name: distrust
+    volumes:
+      - ./distrust.yml:/distrust.yml:Z
+    ports:
+      - 3000:3000


### PR DESCRIPTION
Hi! I've tested the compose file and it works fine.

```console
# env 'VERSION=0.1.0' podman-compose up -d distrust
podman-compose version: 1.0.6
['podman', '--version', '']
using podman version: 4.9.3
** excluding:  set()
['podman', 'ps', '--filter', 'label=io.podman.compose.project=distrust', '-a', '--format', '{{ index .Labels "io.podman.compose.config-hash"}}']
['podman', 'network', 'exists', 'distrust_default']
podman run --name=distrust -d --label io.podman.compose.config-hash=b97f9a96343a897e8ab51881a2906857d3c79388c8a90b55083235f5d2d72631 --label io.podman.compose.project=distrust --label io.podman.compose.version=1.0.6 --label PODMAN_SYSTEMD_UNIT=podman-compose@distrust.service --label com.docker.compose.project=distrust --label com.docker.compose.project.working_dir=/root/discourse-oidc/distrust --label com.docker.compose.project.config_files=docker-compose.yml --label com.docker.compose.container-number=1 --label com.docker.compose.service=distrust -v /root/discourse-oidc/distrust/distrust.yml:/distrust.yml:Z --net distrust_default --network-alias distrust -p 3000:3000 ghcr.io/parkour-vienna/distrust:0.1.0
Trying to pull ghcr.io/parkour-vienna/distrust:0.1.0...
Getting image source signatures
Copying blob d3c894b5b2b0 done   |
Copying blob 63b450eae87c done   |
Copying blob b4ca4c215f48 done   |
Copying blob 960043b8858c done   |
Copying blob eebb06941f3e done   |
Copying blob 02cd68c0cbf6 done   |
Copying blob b40161cd83fc done   |
Copying blob 46ba3f23f1d3 done   |
Copying blob 4fa131a1b726 done   |
Copying blob 35a1dd822544 done   |
Copying config bcf0eeba29 done   |
Writing manifest to image destination
bfcde566967dd1cd9692763b6adecf1c21389610cbc035df26b1ed6aa62676ca
exit code: 0

# podman-compose ps
podman-compose version: 1.0.6
['podman', '--version', '']
using podman version: 4.9.3
podman ps -a --filter label=io.podman.compose.project=distrust
CONTAINER ID  IMAGE                                  COMMAND     CREATED             STATUS             PORTS                   NAMES
bfcde566967d  ghcr.io/parkour-vienna/distrust:0.1.0              About a minute ago  Up About a minute  0.0.0.0:3000->3000/tcp  distrust
exit code: 0

```

This is a subset work of #6.